### PR TITLE
[bug] Metamask payment option, network issue

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -118,7 +118,7 @@ export default {
   async connectToWallet(wallet, addressfunc, updateAddress) {
     this.loading = true
     const chainid = await this.web3.eth.getChainId()
-    if (chainid !== this.method.chain_id)
+    if (Number(chainid) !== this.method.chain_id)
       return this.showError(
         `Please change your network in ${wallet} to work on the ${this.method.currency.toUpperCase()} network (chain id ${
           this.method.chain_id


### PR DESCRIPTION
Reference issue: #172 

`const chainId = this.web3.eth.getChainId()` returns the current chain id of the network connected to metamask

`typeof chainId === "bigint" // true`
`typeof this.method.chainId === "number" // true`

`chainId === this.method.chainId // false`

We need to cast `chainId` to `number`